### PR TITLE
item view model 추가

### DIFF
--- a/app/src/main/java/com/example/bikini_android/ui/common/BindableLayout.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/common/BindableLayout.kt
@@ -1,0 +1,19 @@
+/*
+ * BindableItem.kt 2020. 11. 5
+ *
+ * Copyright 2020 BasicBug. All rights Reserved.
+ *
+ */
+
+package com.example.bikini_android.ui.common
+
+import androidx.annotation.LayoutRes
+
+/**
+ * @author MyeongKi
+ */
+
+interface BindableLayout {
+    @LayoutRes
+    fun getLayoutRes(): Int
+}

--- a/app/src/main/java/com/example/bikini_android/ui/common/ItemViewModel.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/common/ItemViewModel.kt
@@ -1,0 +1,32 @@
+/*
+ * ItemViewModel.kt 2020. 11. 5
+ *
+ * Copyright 2020 BasicBug. All rights Reserved.
+ *
+ */
+
+package com.example.bikini_android.ui.common
+
+import androidx.databinding.BaseObservable
+import androidx.databinding.Bindable
+import com.example.bikini_android.BR
+import com.example.bikini_android.util.bus.RxAction
+import com.jakewharton.rxrelay2.Relay
+
+/**
+ * @author MyeongKi
+ */
+
+abstract class ItemViewModel : BaseObservable(), BindableLayout {
+    @get:Bindable
+    var enabled = true
+        set(value) {
+            field = value
+            notifyPropertyChanged(BR.enabled)
+        }
+
+    var itemEventRelay: Relay<RxAction>? = null
+
+    fun onClickItem() = Unit
+    fun onLongClickItem() = Unit
+}


### PR DESCRIPTION
아이템 뷰모델 관련 피알이에요
- 뷰모델에서 수행하는 일 중에 아이템뷰에 대한 처리를 이 친구를 통하여 할 수 있어요 (클릭 이벤트, ui 갱신 등의 뉘앙스...)
-> 일반 viewmodel에서 여러 아이템 뷰모델과 repo를 갖고 있는? 그런 구조로 보면 될거 같아요.. 
-> 그리고 xml을 인클루드 할 때 부모 xml에서 databinding adapter을 따로 정의하지 않고 해당 인클루된 xml의 데이터를 부모 xml에서 주입이 가능하더라구요.. 해당 부분은 다음에 적용할 때 코멘트로 남겨둘게요.