### PR TITLE
Fix #115 type casting to String

### DIFF
--- a/app/src/debug/java/com/example/bikini_android/ui/settings/SettingsFragment.kt
+++ b/app/src/debug/java/com/example/bikini_android/ui/settings/SettingsFragment.kt
@@ -29,7 +29,7 @@ class SettingsFragment : BaseSettingsFragment() {
                 Preference.OnPreferenceChangeListener { preference, serverType ->
                     logger.debug { "changed serverType $serverType" }
                     with(requireActivity().pref()) {
-                        put(PREF_SERVER_TYPE, serverType)
+                        put(PREF_SERVER_TYPE, serverType.toString())
                     }
                     preference.summary = serverType.toString()
                     true


### PR DESCRIPTION
String 타입으로 캐스팅

Preference 에서 callback 으로 전달받은 값은 Any 타입 (Java 의 Object) 이므로
SharedPreference 의 put 함수로 전달될 때 T class 가 Object class 로 인식되어 미리 정의해둔 데이터 타입에
해당되지 않아 정상적으로 저장되지 않음.

Signed-off-by: qwebnm7788 <qwebnm7788@naver.com>