### PR TITLE
#100 맵 관련 메모리 누수

### DIFF
--- a/app/src/main/java/com/example/bikini_android/ui/base/BaseSettingsFragment.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/base/BaseSettingsFragment.kt
@@ -1,5 +1,5 @@
 /*
- * BaseSettingsFragment.kt 2021. 2. 19
+ * BaseSettingsFragment.kt 2021. 3. 17
  *
  * Copyright 2021 BasicBug. All rights Reserved.
  *

--- a/app/src/main/java/com/example/bikini_android/ui/holder/FeedsViewModelsProvider.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/holder/FeedsViewModelsProvider.kt
@@ -1,0 +1,42 @@
+/*
+ * FeedsViewModelsProvider.kt 2021. 3. 17
+ *
+ * Copyright 2021 BasicBug. All rights Reserved.
+ *
+ */
+
+package com.example.bikini_android.ui.holder
+
+import android.os.Bundle
+import androidx.lifecycle.ViewModelProvider
+import com.example.bikini_android.ui.base.BaseActivity
+import com.example.bikini_android.ui.base.BaseViewModel
+import com.example.bikini_android.ui.feeds.viewmodel.AllFeedsViewModel
+import com.example.bikini_android.ui.feeds.viewmodel.FeedsViewModelFactoryProvider
+import com.example.bikini_android.ui.feeds.viewmodel.MyFeedsViewModel
+import com.example.bikini_android.ui.feeds.viewmodel.RankingFeedsViewModel
+
+/**
+ * @author MyeongKi
+ */
+object FeedsViewModelsProvider {
+    fun getFeedsViewModels(
+        owner: BaseActivity,
+        savedInstanceState: Bundle?
+    ): List<BaseViewModel> {
+        return listOf(
+            ViewModelProvider(
+                owner,
+                FeedsViewModelFactoryProvider(owner, savedInstanceState)
+            )[RankingFeedsViewModel::class.java],
+            ViewModelProvider(
+                owner,
+                FeedsViewModelFactoryProvider(owner, savedInstanceState)
+            )[AllFeedsViewModel::class.java],
+            ViewModelProvider(
+                owner,
+                FeedsViewModelFactoryProvider(owner, savedInstanceState)
+            )[MyFeedsViewModel::class.java]
+        )
+    }
+}

--- a/app/src/main/java/com/example/bikini_android/ui/holder/MainHolderViewModelsHelper.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/holder/MainHolderViewModelsHelper.kt
@@ -8,14 +8,9 @@
 package com.example.bikini_android.ui.holder
 
 import android.os.Bundle
-import androidx.lifecycle.ViewModelProvider
 import com.example.bikini_android.ui.base.BaseActivity
 import com.example.bikini_android.ui.base.BaseViewModel
 import com.example.bikini_android.ui.common.ViewModelsHelper
-import com.example.bikini_android.ui.feeds.viewmodel.AllFeedsViewModel
-import com.example.bikini_android.ui.feeds.viewmodel.FeedsViewModelFactoryProvider
-import com.example.bikini_android.ui.feeds.viewmodel.MyFeedsViewModel
-import com.example.bikini_android.ui.feeds.viewmodel.RankingFeedsViewModel
 
 /**
  * @author MyeongKi
@@ -27,20 +22,10 @@ object MainHolderViewModelsHelper : ViewModelsHelper {
         owner: BaseActivity,
         savedInstanceState: Bundle?
     ): List<BaseViewModel> {
-        return listOf(
-            ViewModelProvider(
-                owner,
-                FeedsViewModelFactoryProvider(owner, savedInstanceState)
-            )[RankingFeedsViewModel::class.java],
-            ViewModelProvider(
-                owner,
-                FeedsViewModelFactoryProvider(owner, savedInstanceState)
-            )[AllFeedsViewModel::class.java],
-            ViewModelProvider(
-                owner,
-                FeedsViewModelFactoryProvider(owner, savedInstanceState)
-            )[MyFeedsViewModel::class.java]
-        )
+        return mutableListOf<BaseViewModel>().apply {
+            addAll(FeedsViewModelsProvider.getFeedsViewModels(owner, savedInstanceState))
+            addAll(MapViewModelsProvider.getMapViewModels(owner, savedInstanceState))
+        }
     }
 
     override fun saveState(viewModels: List<BaseViewModel>) {

--- a/app/src/main/java/com/example/bikini_android/ui/holder/MapViewModelsProvider.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/holder/MapViewModelsProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * MapViewModelsProvider.kt 2021. 3. 17
+ *
+ * Copyright 2021 BasicBug. All rights Reserved.
+ *
+ */
+
+package com.example.bikini_android.ui.holder
+
+import android.os.Bundle
+import androidx.lifecycle.ViewModelProvider
+import com.example.bikini_android.ui.base.BaseActivity
+import com.example.bikini_android.ui.base.BaseViewModel
+import com.example.bikini_android.ui.map.viewmodel.BikiniMapViewModel
+import com.example.bikini_android.ui.map.viewmodel.MapViewModelFactoryProvider
+
+/**
+ * @author MyeongKi
+ */
+object MapViewModelsProvider {
+    fun getMapViewModels(
+        owner: BaseActivity,
+        savedInstanceState: Bundle?
+    ): List<BaseViewModel> {
+        return listOf(
+            ViewModelProvider(
+                owner,
+                MapViewModelFactoryProvider(owner, savedInstanceState)
+            )[BikiniMapViewModel::class.java]
+        )
+    }
+}

--- a/app/src/main/java/com/example/bikini_android/ui/map/BikiniMapFragment.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/map/BikiniMapFragment.kt
@@ -27,6 +27,8 @@ import com.example.bikini_android.ui.feeds.FeedsSortType
 import com.example.bikini_android.ui.feeds.FeedsType
 import com.example.bikini_android.ui.feeds.viewmodel.FeedsViewModel
 import com.example.bikini_android.ui.feeds.viewmodel.FeedsViewModelFactoryProvider
+import com.example.bikini_android.ui.map.viewmodel.BikiniMapViewModel
+import com.example.bikini_android.ui.map.viewmodel.MapViewModelFactoryProvider
 import com.example.bikini_android.util.map.GoogleMapUtils
 import com.example.bikini_android.util.rx.addTo
 import com.google.android.gms.maps.GoogleMap
@@ -38,15 +40,26 @@ import io.reactivex.android.schedulers.AndroidSchedulers
 
 class BikiniMapFragment : BaseMapFragment() {
     private var binding: FragmentBikiniMapBinding? = null
-    private lateinit var viewModel: FeedsViewModel
+    private lateinit var feedsViewModel: FeedsViewModel
 
     private val feedMarkerBindingTable = ArrayMap<Feed, ViewFeedMarkerBinding>()
     private val feedAddedToMapTable = ArrayMap<String, Feed>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        mapViewModel = ViewModelProvider(
+            this,
+            MapViewModelFactoryProvider(this, savedInstanceState)
+        )[BikiniMapViewModel::class.java]
+        feedsViewModel = ViewModelProvider(
+            requireActivity(),
+            FeedsViewModelFactoryProvider(
+                requireActivity(),
+                savedInstanceState
+            )
+        ).get(FeedsViewModelFactoryProvider.getFeedViewModelClazz(MAP_FEEDS_TYPE))
         arguments?.let {
-            locationFocused = it.getParcelable(KEY_LOCATION_INFO)
+            mapViewModel.locationFocused = it.getParcelable(KEY_LOCATION_INFO)
         }
     }
 
@@ -63,21 +76,16 @@ class BikiniMapFragment : BaseMapFragment() {
         ).also {
             super.onCreateView(inflater, container, savedInstanceState)
             binding = it
-            viewModel = ViewModelProvider(
-                requireActivity(),
-                FeedsViewModelFactoryProvider(
-                    requireActivity(),
-                    savedInstanceState
-                )
-            ).get(FeedsViewModelFactoryProvider.getFeedViewModelClazz(MAP_FEEDS_TYPE))
-            itemEventRelay = viewModel.itemEventRelay
+            mapView = it.map.also { view ->
+                view.getMapAsync(this)
+            }
         }.root
 
     override fun onMapReady(googleMap: GoogleMap?) {
         super.onMapReady(googleMap)
         observeEvent()
         initMap()
-        viewModel.loadFeeds()
+        feedsViewModel.loadFeeds()
     }
 
     override fun onDestroyView() {
@@ -87,7 +95,7 @@ class BikiniMapFragment : BaseMapFragment() {
     }
 
     private fun initMap() {
-        map.setOnMarkerClickListener { marker ->
+        map.get()?.setOnMarkerClickListener { marker ->
             feedAddedToMapTable[marker.tag]?.let { feed ->
                 navigateNearLocationFeeds(feed)
             }
@@ -107,25 +115,26 @@ class BikiniMapFragment : BaseMapFragment() {
     }
 
     private fun observeEvent() {
-        itemEventRelay
+        fragmentItemEventRelay
             .ofType(FeedMarkerImageLoadEvent::class.java)
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe { event ->
                 addMarker(event.feed)
             }.addTo(disposables)
 
-        itemEventRelay
+        fragmentItemEventRelay
+            .ofType(MapLocationChangeEvent::class.java)
+            .observeOn(AndroidSchedulers.mainThread())
+            .subscribe { event ->
+                feedsViewModel.loadFeeds(event.latLng, event.visibleRadius)
+            }.addTo(disposables)
+
+        feedsViewModel.itemEventRelay
             .ofType(FeedsEvent::class.java)
             .observeOn(AndroidSchedulers.mainThread())
             .filter { it.feedsType == MAP_FEEDS_TYPE }
             .subscribe { event ->
                 bindFeedMarkers(event.feeds)
-            }.addTo(disposables)
-        itemEventRelay
-            .ofType(MapLocationChangeEvent::class.java)
-            .observeOn(AndroidSchedulers.mainThread())
-            .subscribe { event ->
-                viewModel.loadFeeds(event.latLng, event.visibleRadius)
             }.addTo(disposables)
     }
 
@@ -137,13 +146,15 @@ class BikiniMapFragment : BaseMapFragment() {
     private fun addMarker(feed: Feed) {
         feedMarkerBindingTable[feed]?.root?.let { view ->
             feed.locationInfo?.let { locationInfo ->
-                map.addMarker(GoogleMapUtils.getFeedMarkerOption(view, locationInfo))
-                    .apply {
-                        tag = feed.feedId
-                    }
-                    .also {
-                        feedAddedToMapTable[feed.feedId] = feed
-                    }
+                map.get()?.let {
+                    it.addMarker(GoogleMapUtils.getFeedMarkerOption(view, locationInfo))
+                        .apply {
+                            tag = feed.feedId
+                        }
+                        .also {
+                            feedAddedToMapTable[feed.feedId] = feed
+                        }
+                }
 
             }
         }
@@ -156,7 +167,7 @@ class BikiniMapFragment : BaseMapFragment() {
                     feedMarkerBindingTable[feed] = this
                     apply {
                         viewmodel = FeedMarkerItemViewModel(feed).also {
-                            it.itemEventRelay = itemEventRelay
+                            it.itemEventRelay = fragmentItemEventRelay
                         }
                         executePendingBindings()
                     }

--- a/app/src/main/java/com/example/bikini_android/ui/map/viewmodel/BikiniMapViewModel.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/map/viewmodel/BikiniMapViewModel.kt
@@ -1,0 +1,17 @@
+/*
+ * BikiniMapViewModel.kt 2021. 3. 17
+ *
+ * Copyright 2021 BasicBug. All rights Reserved.
+ *
+ */
+
+package com.example.bikini_android.ui.map.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+
+/**
+ * @author MyeongKi
+ */
+class BikiniMapViewModel(handle: SavedStateHandle) : MapViewModel(handle) {
+
+}

--- a/app/src/main/java/com/example/bikini_android/ui/map/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/map/viewmodel/MapViewModel.kt
@@ -1,0 +1,58 @@
+/*
+ * MapViewModel.kt 2021. 3. 17
+ *
+ * Copyright 2021 BasicBug. All rights Reserved.
+ *
+ */
+
+package com.example.bikini_android.ui.map.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import com.example.bikini_android.repository.feed.LocationInfo
+import com.example.bikini_android.ui.base.BaseMapFragment
+import com.example.bikini_android.ui.base.BaseViewModel
+import com.example.bikini_android.util.bus.RxAction
+import com.example.bikini_android.util.map.LocationUtils
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.model.LatLng
+import com.jakewharton.rxrelay2.PublishRelay
+import com.jakewharton.rxrelay2.Relay
+
+/**
+ * @author MyeongKi
+ */
+abstract class MapViewModel(private val handle: SavedStateHandle) : BaseViewModel() {
+    val itemEventRelay: Relay<RxAction> = PublishRelay.create()
+    var locationFocused: LocationInfo? = handle.get<LocationInfo>(KEY_LOCATION_FOCUSED)
+    var zoom: Float = handle.get<Float>(KEY_ZOOM) ?: BaseMapFragment.DEFAULT_ZOOM_SIZE
+
+    fun initMap() {
+        if (locationFocused == null) {
+            LocationUtils.getCurrentLocation()?.let {
+                locationFocused = LocationInfo(it.latitude, it.longitude)
+            }
+        }
+        locationFocused?.let {
+            itemEventRelay.accept(MoveToLocationEvent(LatLng(it.latitude, it.longitude), zoom))
+        }
+    }
+
+    fun saveLastState(googleMap: GoogleMap) {
+        googleMap.cameraPosition.target?.let {
+            locationFocused = LocationInfo(it.latitude, it.longitude)
+        }
+        zoom = googleMap.cameraPosition.zoom
+    }
+
+    override fun saveState() {
+        handle[KEY_ZOOM] = zoom
+        handle[KEY_LOCATION_FOCUSED] = locationFocused
+    }
+
+    class MoveToLocationEvent(val latLng: LatLng, val zoom: Float) : RxAction
+
+    companion object {
+        private const val KEY_ZOOM = "keyZoom"
+        private const val KEY_LOCATION_FOCUSED = "keyLocationFocused"
+    }
+}

--- a/app/src/main/java/com/example/bikini_android/ui/map/viewmodel/MapViewModelFactoryProvider.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/map/viewmodel/MapViewModelFactoryProvider.kt
@@ -1,0 +1,39 @@
+/*
+ * MapViewModelFactoryProvider.kt 2021. 3. 17
+ *
+ * Copyright 2021 BasicBug. All rights Reserved.
+ *
+ */
+
+package com.example.bikini_android.ui.map.viewmodel
+
+import android.os.Bundle
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.savedstate.SavedStateRegistryOwner
+
+/**
+ * @author MyeongKi
+ */
+class MapViewModelFactoryProvider(
+    owner: SavedStateRegistryOwner,
+    savedInstanceState: Bundle?
+) : AbstractSavedStateViewModelFactory(owner, savedInstanceState) {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel?> create(
+        key: String,
+        modelClass: Class<T>,
+        handle: SavedStateHandle
+    ): T {
+        return when {
+            modelClass.isAssignableFrom(BikiniMapViewModel::class.java) -> {
+                BikiniMapViewModel(handle) as T
+            }
+            else -> {
+                throw IllegalArgumentException()
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_bikini_map.xml
+++ b/app/src/main/res/layout/fragment_bikini_map.xml
@@ -12,10 +12,10 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.fragment.app.FragmentContainerView
+        <com.google.android.gms.maps.MapView
             xmlns:android="http://schemas.android.com/apk/res/android"
             android:id="@+id/map"
-            class="com.google.android.gms.maps.SupportMapFragment"
+            android:name="com.google.android.gms.maps.MapFragment"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- 우선 기존에 사용하던 방식이 activity 라이프사이클을 따르고있는데 fragment에서 map view를 구성하고 있어서 해당 이슈가 발생.
- mapView의 라이프사이클을 fragment로 옮기는 작업 진행
- fragment로 라이프 사이클이 옮겨감에 따라서 map의 상태가 초기화 되는 현상 발생
- 맵의 상태를 기억하는 mapViewModel 추가
- 맵의 상태를 기억하는 로직은 모든 mapViewModel에 공통적으로 사용할 것으로 보이기 때문에 추상층에 구현체를 구현
- 추가적인 맵의 useCase가 필요한 경우는 mapViewModel을 이어 받은 다른 뷰모델에 추가를 해주는 방식으로 진행하면 될거 같음.