### PR TITLE
Fix #127 난독화 오류 픽스

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-keep class com.example.bikini_android.network.**{*;}
+
+-keep class com.example.bikini_android.repository.**{*;}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -22,4 +22,3 @@
 
 -keep class com.example.bikini_android.network.**{*;}
 
--keep class com.example.bikini_android.repository.**{*;}

--- a/app/src/main/java/com/example/bikini_android/repository/feed/Feed.kt
+++ b/app/src/main/java/com/example/bikini_android/repository/feed/Feed.kt
@@ -1,12 +1,14 @@
 package com.example.bikini_android.repository.feed
 
 import android.os.Parcelable
+import androidx.annotation.Keep
 import kotlinx.parcelize.Parcelize
 
 /**
  * @author bsgreentea
  */
 @Parcelize
+@Keep
 data class Feed(
     var feedId: String = "test1",
     var feedNumOfUser: Int = 0,

--- a/app/src/main/java/com/example/bikini_android/repository/feed/LocationInfo.kt
+++ b/app/src/main/java/com/example/bikini_android/repository/feed/LocationInfo.kt
@@ -8,12 +8,14 @@
 package com.example.bikini_android.repository.feed
 
 import android.os.Parcelable
+import androidx.annotation.Keep
 import kotlinx.parcelize.Parcelize
 
 /**
  * @author MyeongKi
  */
 @Parcelize
+@Keep
 data class LocationInfo(
     val latitude: Double,
     val longitude: Double,


### PR DESCRIPTION
릴리즈 버젼이 계속 죽고 있었네요.. 아무래도 네트워크 통신이 이루어지는 코드의 난독화가 발생하면서 정상적인 송수신이 어려웠고 그로인하여 에러가 발생한거 같네요. 네트워크 관련 코드는 난독화에서 뺐습니다.
여기서 의문점은 네트워크 패키지 내부에는 api 패스값이 들어있고 해당 부분과 다양한 키값을 난독화가 발생하면서 에러가 발생한거 같은데.. 레포지토리 패키지는 난독화로 인하여 왜 에러가 발생하는지 흠... 🤔