### PR TITLE
#112 송수신 에러 발생시에 동일하게 에러 및 로그 처리

### DIFF
--- a/app/src/main/java/com/example/bikini_android/repository/feed/FeedRepository.kt
+++ b/app/src/main/java/com/example/bikini_android/repository/feed/FeedRepository.kt
@@ -17,16 +17,16 @@ import io.reactivex.Single
 interface FeedRepository {
     fun getUserFeedsFromRemote(
         userId: String
-    ): Single<List<Feed>>
+    ): Single<List<Feed>?>
 
     fun getRankingFeedsFromRemote(
         limit: Int
-    ): Single<List<Feed>>
+    ): Single<List<Feed>?>
 
-    fun getAllFeedsFromRemote(): Single<List<Feed>>
+    fun getAllFeedsFromRemote(): Single<List<Feed>?>
 
     fun getNearbyFeedsFromRemote(
         latLng: LatLng,
         radius: Float
-    ): Single<List<Feed>>
+    ): Single<List<Feed>?>
 }

--- a/app/src/main/java/com/example/bikini_android/repository/feed/FeedRepositoryImpl.kt
+++ b/app/src/main/java/com/example/bikini_android/repository/feed/FeedRepositoryImpl.kt
@@ -10,6 +10,8 @@ package com.example.bikini_android.repository.feed
 import com.example.bikini_android.network.client.ApiClientHelper
 import com.example.bikini_android.network.request.param.NearbyFeedParameter
 import com.example.bikini_android.network.request.service.FeedService
+import com.example.bikini_android.util.error.ErrorToastHelper
+import com.example.bikini_android.util.logging.Logger
 import com.google.android.gms.maps.model.LatLng
 import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
@@ -19,7 +21,13 @@ import io.reactivex.schedulers.Schedulers
  */
 
 class FeedRepositoryImpl private constructor() : FeedRepository {
-    override fun getUserFeedsFromRemote(userId: String): Single<List<Feed>> {
+    private val logger: Logger by lazy(LazyThreadSafetyMode.NONE) {
+        Logger().apply {
+            TAG = "FeedRepositoryImpl"
+        }
+    }
+
+    override fun getUserFeedsFromRemote(userId: String): Single<List<Feed>?> {
         return ApiClientHelper
             .createMainApiByService(FeedService::class)
             .getUserFeeds(userId)
@@ -27,9 +35,13 @@ class FeedRepositoryImpl private constructor() : FeedRepository {
             .map {
                 it.result?.feeds
             }
+            .onErrorReturn { throwable ->
+                ErrorToastHelper.unknownError(logger, throwable)
+                emptyList()
+            }
     }
 
-    override fun getRankingFeedsFromRemote(limit: Int): Single<List<Feed>> {
+    override fun getRankingFeedsFromRemote(limit: Int): Single<List<Feed>?> {
         return ApiClientHelper
             .createMainApiByService(FeedService::class)
             .getRankFeeds(limit)
@@ -37,9 +49,13 @@ class FeedRepositoryImpl private constructor() : FeedRepository {
             .map {
                 it.result?.feeds
             }
+            .onErrorReturn { throwable ->
+                ErrorToastHelper.unknownError(logger, throwable)
+                emptyList()
+            }
     }
 
-    override fun getAllFeedsFromRemote(): Single<List<Feed>> {
+    override fun getAllFeedsFromRemote(): Single<List<Feed>?> {
         return ApiClientHelper
             .createMainApiByService(FeedService::class)
             .getAllFeeds()
@@ -47,9 +63,13 @@ class FeedRepositoryImpl private constructor() : FeedRepository {
             .map {
                 it.result?.feeds
             }
+            .onErrorReturn { throwable ->
+                ErrorToastHelper.unknownError(logger, throwable)
+                emptyList()
+            }
     }
 
-    override fun getNearbyFeedsFromRemote(latLng: LatLng, radius: Float): Single<List<Feed>> {
+    override fun getNearbyFeedsFromRemote(latLng: LatLng, radius: Float): Single<List<Feed>?> {
         return ApiClientHelper
             .createMainApiByService(FeedService::class)
             .getNearbyLocationFeeds(NearbyFeedParameter().apply {
@@ -59,6 +79,10 @@ class FeedRepositoryImpl private constructor() : FeedRepository {
             .subscribeOn(Schedulers.io())
             .map {
                 it.result?.feeds
+            }
+            .onErrorReturn { throwable ->
+                ErrorToastHelper.unknownError(logger, throwable)
+                emptyList()
             }
     }
 

--- a/app/src/main/java/com/example/bikini_android/ui/feeds/LoadAllFeedsUseCase.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/feeds/LoadAllFeedsUseCase.kt
@@ -38,11 +38,11 @@ class LoadAllFeedsUseCase(
                 .getAllFeedsFromRemote()
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    itemEventRelay.accept(FeedsEvent(it, FeedsType.ALL_FEEDS))
-                }, {
-                    logger.error { it.toString() }
-                })
+                .subscribe { result ->
+                    result?.let {
+                        itemEventRelay.accept(FeedsEvent(it, FeedsType.ALL_FEEDS))
+                    }
+                }
                 .addTo(disposable)
         }
     }

--- a/app/src/main/java/com/example/bikini_android/ui/feeds/LoadMyFeedsUseCase.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/feeds/LoadMyFeedsUseCase.kt
@@ -7,7 +7,6 @@
 
 package com.example.bikini_android.ui.feeds
 
-import android.util.Log
 import com.example.bikini_android.repository.feed.Feed
 import com.example.bikini_android.repository.feed.FeedRepositoryInjector
 import com.example.bikini_android.ui.map.FeedsEvent
@@ -36,11 +35,11 @@ class LoadMyFeedsUseCase(
                 .getUserFeedsFromRemote(testMyId)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    itemEventRelay.accept(FeedsEvent(it, FeedsType.MY_FEEDS))
-                }, {
-                    Log.d("tset", it.toString())
-                })
+                .subscribe { result ->
+                    result?.let {
+                        itemEventRelay.accept(FeedsEvent(it, FeedsType.MY_FEEDS))
+                    }
+                }
                 .addTo(disposable)
         }
     }

--- a/app/src/main/java/com/example/bikini_android/ui/feeds/LoadNearbyFeedsUseCase.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/feeds/LoadNearbyFeedsUseCase.kt
@@ -70,12 +70,12 @@ class LoadNearbyFeedsUseCase(
             .getNearbyFeedsFromRemote(latLng, radius)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe({
-                cacheNearbyFeedsInfo(latLng, radius, it)
-                itemEventRelay.accept(FeedsEvent(it, FeedsType.NEARBY_FEEDS))
-            }, {
-                logger.error { it.toString() }
-            })
+            .subscribe { result ->
+                result?.let {
+                    cacheNearbyFeedsInfo(latLng, radius, it)
+                    itemEventRelay.accept(FeedsEvent(it, FeedsType.NEARBY_FEEDS))
+                }
+            }
             .addTo(disposable)
     }
 
@@ -94,7 +94,10 @@ class LoadNearbyFeedsUseCase(
 
     private fun isNearbyFeed(latLng: LatLng, radius: Float, feed: Feed): Boolean {
         feed.locationInfo?.let {
-            return LocationUtils.getDistanceBetween(latLng, LatLng(it.latitude, it.longitude)) <= radius
+            return LocationUtils.getDistanceBetween(
+                latLng,
+                LatLng(it.latitude, it.longitude)
+            ) <= radius
         }
         return false
     }

--- a/app/src/main/java/com/example/bikini_android/ui/feeds/LoadRankingFeedsUseCase.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/feeds/LoadRankingFeedsUseCase.kt
@@ -7,7 +7,6 @@
 
 package com.example.bikini_android.ui.feeds
 
-import android.util.Log
 import com.example.bikini_android.repository.feed.Feed
 import com.example.bikini_android.repository.feed.FeedRepositoryInjector
 import com.example.bikini_android.ui.map.FeedsEvent
@@ -35,11 +34,11 @@ class LoadRankingFeedsUseCase(
                 .getRankingFeedsFromRemote(LIMIT)
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .subscribe({
-                    itemEventRelay.accept(FeedsEvent(it, FeedsType.RANKING_FEEDS))
-                }, {
-                    Log.d("tset", it.toString())
-                })
+                .subscribe { result ->
+                    result?.let {
+                        itemEventRelay.accept(FeedsEvent(it, FeedsType.RANKING_FEEDS))
+                    }
+                }
                 .addTo(disposable)
         }
     }

--- a/app/src/main/java/com/example/bikini_android/util/error/ErrorToastHelper.kt
+++ b/app/src/main/java/com/example/bikini_android/util/error/ErrorToastHelper.kt
@@ -1,0 +1,22 @@
+/*
+ * ErrorConsumer.kt 2021. 4. 11
+ *
+ * Copyright 2021 BasicBug. All rights Reserved.
+ *
+ */
+
+package com.example.bikini_android.util.error
+
+import com.example.bikini_android.R
+import com.example.bikini_android.app.ToastHelper
+import com.example.bikini_android.util.logging.Logger
+
+/**
+ * @author MyeongKi
+ */
+object ErrorToastHelper {
+    fun unknownError(logger: Logger, throwable: Throwable) {
+        logger.error { throwable.toString() }
+        ToastHelper.show(R.string.unknown_error_message)
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,6 @@
     <string name="location_permission_denied">해당 권한 없이는 앱을 사용할 수 없습니다.</string>
     <!--common-->
     <string name="confirm">확인</string>
+    <string name="unknown_error_message">잠시 후 다시 이용해 주세요.</string>
+
 </resources>


### PR DESCRIPTION
구독하는 쪽에서 로그처리하기 보다는 repo쪽에서 에러를 처리하는 방식으로 수정하였습니다. 그리고 error 토스트를 나중 가면은 error code 별로 처리를 진행해야 할거 같아서 error toast helper를 분리하여 보았습니다.