### PR TITLE
Fix #180 화면이 다시 그려지는 순간에 cast 크러시 발생하는 이슈 수정

### DIFF
--- a/app/src/main/java/com/example/bikini_android/ui/feeds/FeedsFragment.kt
+++ b/app/src/main/java/com/example/bikini_android/ui/feeds/FeedsFragment.kt
@@ -53,8 +53,16 @@ class FeedsFragment : BaseFragment() {
                 it.getString(KEY_SORT_TYPE_NAME) ?: FeedsSortType.NEAR_DISTANCE.name
             )
 
-            @Suppress("UNCHECKED_CAST")
-            feedsReceived = (it.getParcelableArray(KEY_FEEDS) as Array<Feed>?)?.toList()
+            val feedsParcelableArray = it.getParcelableArray(KEY_FEEDS)
+            feedsParcelableArray?.let {
+                val tempFeeds = mutableListOf<Feed>()
+                feedsParcelableArray.forEach { feedParcelable ->
+                    (feedParcelable as? Feed)?.let { feed ->
+                        tempFeeds.add(feed)
+                    }
+                }
+                feedsReceived = tempFeeds
+            }
         }
     }
 
@@ -110,7 +118,8 @@ class FeedsFragment : BaseFragment() {
                         RecyclerViewLayoutType.VERTICAL,
                         feedsType,
                         sortType,
-                        event.feed
+                        event.feed,
+                        feedsReceived
                     )
                 )
             }.addTo(disposables)


### PR DESCRIPTION
### 발생 경로
개발자 모드에서 화면 전환시에 유지를 off(앱 대기에서 다시 앱을 실행하는 경우에 다시 화면을 만들도록 설정)
피드를 수직으로 그려주는 화면을 몇번 왔다 갔다 하면 크러시 발생

### 원인
다시 그려지는 순간에 곧 바로 한번에 it.getParcelableArray-> Array<Feed>로 캐스팅하면서 발생

### 해결
아이템 별로 캐스팅 시도하여 리스트에 캐스팅이 완료된 임시 인스턴스를 넣어주는 방식으로 수정