### PR TITLE
#217 토큰 갱신시에 발생하는 에러 처리

### DIFF
--- a/app/src/main/java/com/example/bikini_android/network/TokenAuthenticator.kt
+++ b/app/src/main/java/com/example/bikini_android/network/TokenAuthenticator.kt
@@ -13,6 +13,7 @@ import com.example.bikini_android.manager.PreferenceManager
 import com.example.bikini_android.manager.login.LoginManagerProxy
 import com.example.bikini_android.network.client.ApiClientHelper
 import com.example.bikini_android.network.request.service.AuthService
+import com.example.bikini_android.util.logging.Logger
 import okhttp3.Authenticator
 import okhttp3.Request
 import okhttp3.Response
@@ -22,8 +23,19 @@ import okhttp3.Route
  * @author MyeongKi
  */
 class TokenAuthenticator : Authenticator {
+    private val logger: Logger by lazy(LazyThreadSafetyMode.NONE) {
+        Logger().apply {
+            TAG = "TokenAuthenticator"
+        }
+    }
+
     override fun authenticate(route: Route?, response: Response): Request {
-        updatedToken()
+        try {
+            updatedToken()
+        } catch (e: NullPointerException) {
+            logger.error { e.toString() }
+        }
+
         return response.request.newBuilder()
             .header(
                 "X-AUTH-TOKEN", LoginManagerProxy.accessToken
@@ -38,12 +50,16 @@ class TokenAuthenticator : Authenticator {
                 PreferenceManager.getString(AppResources.getString(R.string.access_token)),
                 LoginManagerProxy.refreshToken
             )
+            .onErrorReturn {
+                null
+            }
             .blockingGet()
+
         authTokenResponse.result?.let {
             LoginManagerProxy.accessToken = it.accessToken
             LoginManagerProxy.refreshToken = it.refreshToken
             return
         }
-        throw NullPointerException("refresh api fail")
+        throw NullPointerException("refresh api fail ${authTokenResponse.result.toString()}")
     }
 }


### PR DESCRIPTION
# 수정
- 토큰 갱신 에러 철

# 원인
- 토큰 갱신 직전에 여러개의 api를 한번에 요청한 경우에 발생함.